### PR TITLE
fix(nix): add correct buildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,26 +1,41 @@
 {
   lib,
+  darwin,
+  stdenv,
+  openssl,
+  pkg-config,
   rustPlatform,
   version ? "latest",
-  pkg-config,
   ...
-}:
-rustPlatform.buildRustPackage {
-  pname = "nixpkgs-using";
-  inherit version;
+}: let
+  inherit (darwin.apple_sdk.frameworks) Security CoreFoundation SystemConfiguration;
+in
+  rustPlatform.buildRustPackage {
+    pname = "nixpkgs-using";
+    inherit version;
 
-  src = ./.;
-  cargoLock.lockFile = ./Cargo.lock;
+    src = ./.;
+    cargoLock.lockFile = ./Cargo.lock;
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+    buildInputs =
+      [
+        openssl
+      ]
+      ++ lib.optionals stdenv.isDarwin [
+        Security
+        CoreFoundation
+        SystemConfiguration
+      ];
 
-  meta = {
-    description = "Find packages that you use that are currently being updated in Nixpkgs.";
-    homepage = "https://github.com/uncenter/nixpkgs-using";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [uncenter];
-    mainProgram = "nixpkgs-using";
-  };
-}
+    nativeBuildInputs = [
+      pkg-config
+    ];
+
+    meta = {
+      description = "Find packages that you use that are currently being updated in Nixpkgs.";
+      homepage = "https://github.com/uncenter/nixpkgs-using";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [uncenter];
+      mainProgram = "nixpkgs-using";
+    };
+  }


### PR DESCRIPTION
This adds the necessary build inputs such that the package builds on Darwin and Linux.